### PR TITLE
Removed unneeded NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,0 @@
-                           Apache Mina
-              Copyright 2020 The Apache Software Foundation
-
-================================================================================
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).


### PR DESCRIPTION
As http://www.apache.org/legal/src-headers.html#faq-webpages describes a NOTICE file is not needed for websites.

```
Does this policy also apply to content displayed on our web sites?

No. Our web sites do not have an associated NOTICE file. Instead we 
may soon be making the terms of such content explicit through a 
"Terms of Use" or "Legal Information" link in the footer of web pages. 
At this point, no action is required for Apache web sites.
```